### PR TITLE
Add Dockerfile and update Readme on how to run the app via Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Use the official .NET SDK to build the app
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the csproj and restore dependencies
+COPY ["Polyglot/*.csproj", "./Polyglot/"]
+WORKDIR /app/Polyglot
+RUN dotnet restore
+
+# Copy the rest of the app source code
+COPY . ./
+
+# Build the project
+RUN dotnet publish -c Release -o /out
+
+# Use a smaller runtime image for running the app
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the build output from the previous stage
+COPY --from=build-env /out .
+
+# Run the app
+ENTRYPOINT ["dotnet", "Polyglot.dll"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ A simple Blazor app which converts libraries of saved links between the native f
 
 ## General Usage
 
+### Docker
+
+Ensure you have Docker installed. Use the provided Dockerfile to build the app by running `docker build -t polyglot .`.
+Now you can run the app with `docker run -p 8080:8080 polyglot`. You can then access the app at `http://localhost:8080`.
+
+### Locally
+
 Ensure that the latest .NET 8 SDK is installed on the host system. Then simply clone into the repo and execute `dotnet run --project Polyglot` from the project directory. Navigate to the URL indicated in the `dotnet run` command output, and you will be presented with a simple interface allowing you to choose the input format (i.e. your current read-it-later service), the output format (i.e. the read-it-later service you wish to import your library into), and finally the input file itself. After uploading your input file, the exported result of the format conversion process will immediately be available in the default download directory of your current browser.
 
 **Please be aware that each read-it-later service has its own particular limitations**. These are detailed below, along with instructions on how to properly import the file provided by this app.

--- a/README.md
+++ b/README.md
@@ -6,12 +6,11 @@ A simple Blazor app which converts libraries of saved links between the native f
 
 ### Docker
 
-Ensure you have Docker installed. Use the provided Dockerfile to build the app by running `docker build -t polyglot .`.
-Now you can run the app with `docker run -p 8080:8080 polyglot`. You can then access the app at `http://localhost:8080`.
+Ensure you have Docker installed and running on your system, then clone into the repo and build the app by running `docker build -t polyglot .`, then start the app by running `docker run -p 8080:8080 polyglot`. You can then access the app by navigating to `http://localhost:8080` in your browser.
 
-### Locally
+### .NET SDK
 
-Ensure that the latest .NET 8 SDK is installed on the host system. Then simply clone into the repo and execute `dotnet run --project Polyglot` from the project directory. Navigate to the URL indicated in the `dotnet run` command output, and you will be presented with a simple interface allowing you to choose the input format (i.e. your current read-it-later service), the output format (i.e. the read-it-later service you wish to import your library into), and finally the input file itself. After uploading your input file, the exported result of the format conversion process will immediately be available in the default download directory of your current browser.
+Ensure that the latest .NET 8 SDK is installed on the host system, then clone into the repo and execute `dotnet run --project Polyglot` from the project directory. Navigate to the URL indicated in the `dotnet run` command output, and you will be presented with a simple interface allowing you to choose the input format (i.e. your current read-it-later service), the output format (i.e. the read-it-later service you wish to import your library into), and finally the input file itself. After uploading your input file, the exported result of the format conversion process will immediately be available in the default download directory of your current browser.
 
 **Please be aware that each read-it-later service has its own particular limitations**. These are detailed below, along with instructions on how to properly import the file provided by this app.
 


### PR DESCRIPTION
This avoids the need to install .NET SDKs and other dependencies on the host machine